### PR TITLE
Use multiple base OS images

### DIFF
--- a/.github/workflows/bullseye-experimental.yml
+++ b/.github/workflows/bullseye-experimental.yml
@@ -17,14 +17,29 @@ on:
 env:
   DISTRO_NAME: "bullseye"
   REPO_NAME: "experimental"
-  RASPI_OS_IMG: "2021-10-30-raspios-bullseye-armhf"
-  RASPI_OS_URL: "https://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf.zip"
-  # 64-bit:
-  # RASPI_OS_IMG: 2021-10-30-raspios-bullseye-arm64
-  # RASPI_OS_URL: https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2021-11-08/2021-10-30-raspios-bullseye-arm64.zip
+
 jobs:
   build:
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - raspi_os_img: "2021-10-30-raspios-bullseye-armhf-lite"
+            raspi_os_url: "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-lite.zip"
+
+          - raspi_os_img: "2021-10-30-raspios-bullseye-armhf"
+            raspi_os_url: "https://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf.zip"
+
+          - raspi_os_img: "2021-10-30-raspios-bullseye-armhf-full"
+            raspi_os_url: "https://downloads.raspberrypi.org/raspios_full_armhf/images/raspios_full_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-full.zip"
+
+          - raspi_os_img: "2021-10-30-raspios-bullseye-arm64-lite"
+            raspi_os_url: "https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-11-08/2021-10-30-raspios-bullseye-arm64-lite.zip"
+
+          - raspi_os_img: "2021-10-30-raspios-bullseye-arm64"
+            raspi_os_url: "https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2021-11-08/2021-10-30-raspios-bullseye-arm64.zip"
+
     steps:
       - name: GitHub Environment Variables Action
         uses: FranzDiebold/github-env-vars-action@v1.2.1
@@ -47,12 +62,12 @@ jobs:
           ANSIBLE="sudo $(which ansible-playbook) -i inventory -vv"
 
           echo "==> Running get_raspios playbook..."
-          ${ANSIBLE} --extra-vars raspi_os_url=${{ env.RASPI_OS_URL }} \
-                     --extra-vars image_name=${{ env.RASPI_OS_IMG }} \
+          ${ANSIBLE} --extra-vars raspi_os_url=${{ ${{ matrix.raspi_os_url }} \
+                     --extra-vars image_name=${{ ${{ matrix.raspi_os_img }} \
                      playbooks/get_raspios.yml
 
           echo "==> Running mount_raspios playbook..."
-          ${ANSIBLE} --extra-vars image_name=${{ env.RASPI_OS_IMG }} \
+          ${ANSIBLE} --extra-vars image_name=${{ ${{ matrix.raspi_os_img }} \
                      playbooks/mount_raspios.yml
 
           echo "==> Running create_pi_top_os_image playbook..."


### PR DESCRIPTION
64-bit builds, as well as lite/full images.
Note that most of these images will not be desirable/usable, but building them will help us to understand what changes are needed in order to provide, for example, 'pi-topOS Lite' (headless).