### PR TITLE
Use multiple base OS images

### DIFF
--- a/.github/workflows/bullseye-experimental.yml
+++ b/.github/workflows/bullseye-experimental.yml
@@ -17,14 +17,29 @@ on:
 env:
   DISTRO_NAME: "bullseye"
   REPO_NAME: "experimental"
-  RASPI_OS_IMG: "2021-10-30-raspios-bullseye-armhf"
-  RASPI_OS_URL: "https://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf.zip"
-  # 64-bit:
-  # RASPI_OS_IMG: 2021-10-30-raspios-bullseye-arm64
-  # RASPI_OS_URL: https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2021-11-08/2021-10-30-raspios-bullseye-arm64.zip
+
 jobs:
   build:
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - raspi_os_img: "2021-10-30-raspios-bullseye-armhf-lite"
+            raspi_os_url: "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-lite.zip"
+
+          - raspi_os_img: "2021-10-30-raspios-bullseye-armhf"
+            raspi_os_url: "https://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf.zip"
+
+          - raspi_os_img: "2021-10-30-raspios-bullseye-armhf-full"
+            raspi_os_url: "https://downloads.raspberrypi.org/raspios_full_armhf/images/raspios_full_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-full.zip"
+
+          - raspi_os_img: "2021-10-30-raspios-bullseye-arm64-lite"
+            raspi_os_url: "https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-11-08/2021-10-30-raspios-bullseye-arm64-lite.zip"
+
+          - raspi_os_img: "2021-10-30-raspios-bullseye-arm64"
+            raspi_os_url: "https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2021-11-08/2021-10-30-raspios-bullseye-arm64.zip"
+
     steps:
       - name: GitHub Environment Variables Action
         uses: FranzDiebold/github-env-vars-action@v1.2.1
@@ -47,12 +62,12 @@ jobs:
           ANSIBLE="sudo $(which ansible-playbook) -i inventory -vv"
 
           echo "==> Running get_raspios playbook..."
-          ${ANSIBLE} --extra-vars raspi_os_url=${{ env.RASPI_OS_URL }} \
-                     --extra-vars image_name=${{ env.RASPI_OS_IMG }} \
+          ${ANSIBLE} --extra-vars raspi_os_url=${{ ${{ matrix.raspi_os_url }} \
+                     --extra-vars image_name=${{ ${{ matrix.raspi_os_img }} \
                      playbooks/get_raspios.yml
 
           echo "==> Running mount_raspios playbook..."
-          ${ANSIBLE} --extra-vars image_name=${{ env.RASPI_OS_IMG }} \
+          ${ANSIBLE} --extra-vars image_name=${{ ${{ matrix.raspi_os_img }} \
                      playbooks/mount_raspios.yml
 
           echo "==> Running create_pi_top_os_image playbook..."

--- a/.github/workflows/bullseye-experimental.yml
+++ b/.github/workflows/bullseye-experimental.yml
@@ -17,6 +17,8 @@ on:
 env:
   DISTRO_NAME: "bullseye"
   REPO_NAME: "experimental"
+  BUILD_DATE: "2021-10-30"
+  RELEASE_DATE: "2021-11-08"
 
 jobs:
   build:
@@ -25,20 +27,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - raspi_os_img: "2021-10-30-raspios-bullseye-armhf-lite"
-            raspi_os_url: "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-lite.zip"
+          # 32-bit Lite
+          - build_type_name: "armhf-lite"
+            build_type_dir: "raspios_lite_armhf"
 
-          - raspi_os_img: "2021-10-30-raspios-bullseye-armhf"
-            raspi_os_url: "https://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf.zip"
+          # 32-bit Regular
+          - build_type_name: "armhf"
+            build_type_dir: "raspios_armhf"
 
-          - raspi_os_img: "2021-10-30-raspios-bullseye-armhf-full"
-            raspi_os_url: "https://downloads.raspberrypi.org/raspios_full_armhf/images/raspios_full_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-full.zip"
+          # 32-bit Full
+          - build_type_name: "armhf-full"
+            build_type_dir: "raspios_full_armhf"
 
-          - raspi_os_img: "2021-10-30-raspios-bullseye-arm64-lite"
-            raspi_os_url: "https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-11-08/2021-10-30-raspios-bullseye-arm64-lite.zip"
+          # 64-bit Lite
+          - build_type_name: "arm64-lite"
+            build_type_dir: "raspios_lite_arm64"
 
-          - raspi_os_img: "2021-10-30-raspios-bullseye-arm64"
-            raspi_os_url: "https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2021-11-08/2021-10-30-raspios-bullseye-arm64.zip"
+          # 64-bit Regular
+          - build_type_name: "arm64"
+            build_type_dir: "raspios_arm64"
 
     steps:
       - name: GitHub Environment Variables Action
@@ -55,19 +62,24 @@ jobs:
 
       - name: Build
         run: |
+          set -x
+
           export ANSIBLE_FORCE_COLOR=true
           export TERM=xterm-color
           # chroot connection requires running as root
           # 'ansible-playbook' is not in root user's PATH
           ANSIBLE="sudo $(which ansible-playbook) -i inventory -vv"
 
+          image_name="${{ env.BUILD_DATE }}-raspios-${{ env.DISTRO_NAME }}-${{ matrix.build_type_name }}"
+          url="https://downloads.raspberrypi.org/${{ matrix.build_type_dir }}/images/${{ matrix.build_type_dir }}-${{env.RELEASE_DATE}}/${image_name}.zip"
+
           echo "==> Running get_raspios playbook..."
           ${ANSIBLE} --extra-vars raspi_os_url=${{ matrix.raspi_os_url }} \
-                     --extra-vars image_name=${{ matrix.raspi_os_img }} \
+                     --extra-vars image_name=${image_name} \
                      playbooks/get_raspios.yml
 
           echo "==> Running mount_raspios playbook..."
-          ${ANSIBLE} --extra-vars image_name=${{ matrix.raspi_os_img }} \
+          ${ANSIBLE} --extra-vars image_name=${image_name} \
                      playbooks/mount_raspios.yml
 
           echo "==> Running create_pi_top_os_image playbook..."

--- a/.github/workflows/bullseye-experimental.yml
+++ b/.github/workflows/bullseye-experimental.yml
@@ -74,7 +74,7 @@ jobs:
           url="https://downloads.raspberrypi.org/${{ matrix.build_type_dir }}/images/${{ matrix.build_type_dir }}-${{env.RELEASE_DATE}}/${image_name}.zip"
 
           echo "==> Running get_raspios playbook..."
-          ${ANSIBLE} --extra-vars raspi_os_url=${{ matrix.raspi_os_url }} \
+          ${ANSIBLE} --extra-vars raspi_os_url=${url} \
                      --extra-vars image_name=${image_name} \
                      playbooks/get_raspios.yml
 

--- a/.github/workflows/bullseye-experimental.yml
+++ b/.github/workflows/bullseye-experimental.yml
@@ -62,12 +62,12 @@ jobs:
           ANSIBLE="sudo $(which ansible-playbook) -i inventory -vv"
 
           echo "==> Running get_raspios playbook..."
-          ${ANSIBLE} --extra-vars raspi_os_url=${{ ${{ matrix.raspi_os_url }} \
-                     --extra-vars image_name=${{ ${{ matrix.raspi_os_img }} \
+          ${ANSIBLE} --extra-vars raspi_os_url=${{ matrix.raspi_os_url }} \
+                     --extra-vars image_name=${{ matrix.raspi_os_img }} \
                      playbooks/get_raspios.yml
 
           echo "==> Running mount_raspios playbook..."
-          ${ANSIBLE} --extra-vars image_name=${{ ${{ matrix.raspi_os_img }} \
+          ${ANSIBLE} --extra-vars image_name=${{ matrix.raspi_os_img }} \
                      playbooks/mount_raspios.yml
 
           echo "==> Running create_pi_top_os_image playbook..."

--- a/playbooks/mount_raspios.yml
+++ b/playbooks/mount_raspios.yml
@@ -102,6 +102,10 @@
         opts: defaults
         state: mounted
 
+    # TODO: /usr/bin/qemu-arm-static for 32-bit, ??? for arm64?
+    #   Check from 'image_name'
+    # TODO: only move preload if 32-bit
+
     # Enable chroot to ARM: https://wiki.debian.org/QemuUserEmulation
     - name: Copy qemu-arm-static to Raspberry Pi OS to enable chrooting
       become: true


### PR DESCRIPTION
64-bit builds, as well as lite/full images.

Note that most of these images will not be desirable/usable, but building them will help us to understand what changes are needed in order to provide, for example, a headless 'pi-topOS Lite' build.

e,.g. `openbox` patch
e.g. `pt-os-headless` top-level package..?
