### PR TITLE
Don't skip configure step if image is already mounted

### DIFF
--- a/playbooks/mount_pi_top_os.yml
+++ b/playbooks/mount_pi_top_os.yml
@@ -15,7 +15,7 @@
         path: "{{ pt_os_mount_point }}/dev/pts"
       register: pt_os_file_details
 
-    - meta: end_play
+    - meta: end_host
       when: pt_os_file_details.stat.exists
 
 

--- a/playbooks/mount_raspios.yml
+++ b/playbooks/mount_raspios.yml
@@ -14,7 +14,7 @@
         path: "{{ raspi_os_mount_point }}/boot"
       register: raspi_os_file_details
 
-    - meta: end_play
+    - meta: end_host
       when: raspi_os_file_details.stat.exists
 
     - set_fact:


### PR DESCRIPTION
Starting from build #[165](https://github.com/pi-top/pi-topOS-Build/actions/runs/1575494591), `ansible` started behaving differently when exiting a playbook using `meta` tasks with value `end_play` in an imported playbook. This is weird since the version of `ansible` in both runs is the same. 

The `meta` task is used to skip a playbook if a certain condition is met. In this case, if an OS image is already mounted in the machine, we don't want to re-mount.

Check:
- [build 165 logs](https://github.com/pi-top/pi-topOS-Build/runs/4513757019?check_suite_focus=true#step:6:8166)
- [build 164 logs](https://github.com/pi-top/pi-topOS-Build/runs/4500453471?check_suite_focus=true#step:6:8166)

This issue caused the build to skip the configure pi-topOS playbook when the pi-topOS image was already mounted, producing Raspberry Pi OS - pi-topOS frankensteins, and of sizes ~4GB instead of the usual ~2GB.

Updating the value of the `meta` task to `end_host` finishes the playbook for the current host, but not for all hosts. This means if a playbook is imported, it won't cause the "parent" playbook to finish if the imported playbook exits.