### PR TITLE
Fix pi-top-os apt source package name

### DIFF
--- a/playbooks/install_pi_top_os.yml
+++ b/playbooks/install_pi_top_os.yml
@@ -22,7 +22,7 @@
 
     - name: Install pi-topOS apt source (required to install 'pt-os')
       apt:
-        name: "pi-top-os-{{ repo_name | replace('release','') }}-apt-source"
+        name: "pi-top-os-{{ repo_name | replace('release','') }}{{ (repo_name == 'release') | ternary('', '-') }}apt-source"
         update_cache: true
         state: latest
         install_recommends: true


### PR DESCRIPTION
Fix how the name of the pi-topOS apt source package (`pi-top-os-XXX-apt-source`) is derived from the provided `repo_name`

Tested on https://ansible.sivel.net/test 

![image](https://user-images.githubusercontent.com/14126805/154313636-8a8bd40b-f492-43ac-925f-490ac15c46cb.png)
