### PR TITLE
Rename img and zip files 

### DIFF
--- a/.github/workflows/bullseye-experimental.yml
+++ b/.github/workflows/bullseye-experimental.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Get zip filename
         run: echo "ZIP_FILENAME=$(find playbooks/artifacts -name "*.zip" | head -n1)" >> $GITHUB_ENV
 
-      -name: Get current date
+      - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 

--- a/.github/workflows/bullseye-experimental.yml
+++ b/.github/workflows/bullseye-experimental.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Upload OS zip artifact
         uses: actions/upload-artifact@v2
         with:
-          name: pi-topOS_{{ env.DISTRO_NAME }}_{{ env.REPO_NAME }}_{{ matrix.build_type_name }}_{{ steps.date.outputs.date }}_B{{ github.run_number || github.run_id }}
+          name: pi-topOS_${{ env.DISTRO_NAME }}_${{ env.REPO_NAME }}_${{ matrix.build_type_name }}_${{ steps.date.outputs.date }}_B${{ github.run_number || github.run_id }}
           if-no-files-found: error
           path: ${{ env.ZIP_FILENAME }}
 

--- a/.github/workflows/bullseye-experimental.yml
+++ b/.github/workflows/bullseye-experimental.yml
@@ -88,7 +88,11 @@ jobs:
                      playbooks/configure_pi_top_os.yml
 
           echo "==> Running finalise_pi_top_image playbook..."
-          ${ANSIBLE} playbooks/finalise_pi_top_image.yml
+          ${ANSIBLE} --extra-vars distro_name=${{ env.DISTRO_NAME }} \
+                     --extra-vars build_number=${{ github.run_number || github.run_id }} \
+                     --extra-vars build_repo_name="${{ env.REPO_NAME }}" \
+                     --extra-vars architecture="${{ matrix.build_type_name }}" \
+                     playbooks/finalise_pi_top_image.yml
 
           echo "==> Running analyse_build playbook..."
           ${ANSIBLE} --extra-vars build_number=${{ github.run_number || github.run_id }} \

--- a/.github/workflows/bullseye-experimental.yml
+++ b/.github/workflows/bullseye-experimental.yml
@@ -116,10 +116,3 @@ jobs:
           path: |
             playbooks/artifacts/*
             !${{ env.ZIP_FILENAME }}
-
-      - name: Upload OS zip to GCS
-        uses: google-github-actions/upload-cloud-storage@v0.4.0
-        with:
-          credentials: ${{ secrets.GOOGLE_CLOUD_UPLOAD_JSON_CREDENTIALS }}
-          path: ${{ env.ZIP_FILENAME }}
-          destination: ${{ secrets.GOOGLE_CLOUD_OS_UPLOAD_BUCKET }}/pi-topOS-${{ env.DISTRO_NAME }}/

--- a/.github/workflows/bullseye-experimental.yml
+++ b/.github/workflows/bullseye-experimental.yml
@@ -101,10 +101,14 @@ jobs:
       - name: Get zip filename
         run: echo "ZIP_FILENAME=$(find playbooks/artifacts -name "*.zip" | head -n1)" >> $GITHUB_ENV
 
+      -name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
       - name: Upload OS zip artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.REPO_NAME }}-${{ env.DISTRO_NAME }}-${{ github.run_number || github.run_id }}-${{ matrix.build_type_name }}
+          name: pi-topOS_{{ env.DISTRO_NAME }}_{{ env.REPO_NAME }}_{{ matrix.build_type_name }}_{{ steps.date.outputs.date }}_B{{ github.run_number || github.run_id }}
           if-no-files-found: error
           path: ${{ env.ZIP_FILENAME }}
 

--- a/.github/workflows/bullseye-stable.yml
+++ b/.github/workflows/bullseye-stable.yml
@@ -77,7 +77,11 @@ jobs:
                      playbooks/configure_pi_top_os.yml
 
           echo "==> Running finalise_pi_top_image playbook..."
-          ${ANSIBLE} playbooks/finalise_pi_top_image.yml
+          ${ANSIBLE} --extra-vars distro_name=${{ env.DISTRO_NAME }} \
+                     --extra-vars build_number=${{ github.run_number || github.run_id }} \
+                     --extra-vars build_repo_name="${{ env.REPO_NAME }}" \
+                     --extra-vars architecture="${{ matrix.build_type_name }}" \
+                     playbooks/finalise_pi_top_image.yml
 
           echo "==> Running analyse_build playbook..."
           ${ANSIBLE} --extra-vars build_number=${{ github.run_number || github.run_id }} \

--- a/.github/workflows/bullseye-stable.yml
+++ b/.github/workflows/bullseye-stable.yml
@@ -90,10 +90,14 @@ jobs:
       - name: Get zip filename
         run: echo "ZIP_FILENAME=$(find playbooks/artifacts -name "*.zip" | head -n1)" >> $GITHUB_ENV
 
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
       - name: Upload OS zip artifact
         uses: actions/upload-artifact@v2
         with:
-          name: pi-topOS-${{ env.REPO_NAME }}-${{ env.DISTRO_NAME }}-${{ github.run_number || github.run_id }}-${{ matrix.build_type_name }}
+          name: pi-topOS_{{ env.DISTRO_NAME }}_{{ env.REPO_NAME }}_{{ matrix.build_type_name }}_{{ steps.date.outputs.date }}_B{{ github.run_number || github.run_id }}
           if-no-files-found: error
           path: ${{ env.ZIP_FILENAME }}
 

--- a/.github/workflows/bullseye-stable.yml
+++ b/.github/workflows/bullseye-stable.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Upload OS zip artifact
         uses: actions/upload-artifact@v2
         with:
-          name: pi-topOS_{{ env.DISTRO_NAME }}_{{ env.REPO_NAME }}_{{ matrix.build_type_name }}_{{ steps.date.outputs.date }}_B{{ github.run_number || github.run_id }}
+          name: pi-topOS_${{ env.DISTRO_NAME }}_${{ env.REPO_NAME }}_${{ matrix.build_type_name }}_${{ steps.date.outputs.date }}_B${{ github.run_number || github.run_id }}
           if-no-files-found: error
           path: ${{ env.ZIP_FILENAME }}
 

--- a/.github/workflows/bullseye-testing.yml
+++ b/.github/workflows/bullseye-testing.yml
@@ -77,7 +77,11 @@ jobs:
                      playbooks/configure_pi_top_os.yml
 
           echo "==> Running finalise_pi_top_image playbook..."
-          ${ANSIBLE} playbooks/finalise_pi_top_image.yml
+          ${ANSIBLE} --extra-vars distro_name=${{ env.DISTRO_NAME }} \
+                     --extra-vars build_number=${{ github.run_number || github.run_id }} \
+                     --extra-vars build_repo_name="${{ env.REPO_NAME }}" \
+                     --extra-vars architecture="${{ matrix.build_type_name }}" \
+                     playbooks/finalise_pi_top_image.yml
 
           echo "==> Running analyse_build playbook..."
           ${ANSIBLE} --extra-vars build_number=${{ github.run_number || github.run_id }} \

--- a/.github/workflows/bullseye-testing.yml
+++ b/.github/workflows/bullseye-testing.yml
@@ -90,10 +90,14 @@ jobs:
       - name: Get zip filename
         run: echo "ZIP_FILENAME=$(find playbooks/artifacts -name "*.zip" | head -n1)" >> $GITHUB_ENV
 
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
       - name: Upload OS zip artifact
         uses: actions/upload-artifact@v2
         with:
-          name: pi-topOS-${{ env.REPO_NAME }}-${{ env.DISTRO_NAME }}-${{ github.run_number || github.run_id }}-${{ matrix.build_type_name }}
+          name: pi-topOS_{{ env.DISTRO_NAME }}_{{ env.REPO_NAME }}_{{ matrix.build_type_name }}_{{ steps.date.outputs.date }}_B{{ github.run_number || github.run_id }}
           if-no-files-found: error
           path: ${{ env.ZIP_FILENAME }}
 

--- a/.github/workflows/bullseye-testing.yml
+++ b/.github/workflows/bullseye-testing.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Upload OS zip artifact
         uses: actions/upload-artifact@v2
         with:
-          name: pi-topOS_{{ env.DISTRO_NAME }}_{{ env.REPO_NAME }}_{{ matrix.build_type_name }}_{{ steps.date.outputs.date }}_B{{ github.run_number || github.run_id }}
+          name: pi-topOS_${{ env.DISTRO_NAME }}_${{ env.REPO_NAME }}_${{ matrix.build_type_name }}_${{ steps.date.outputs.date }}_B${{ github.run_number || github.run_id }}
           if-no-files-found: error
           path: ${{ env.ZIP_FILENAME }}
 

--- a/.github/workflows/bullseye-unstable.yml
+++ b/.github/workflows/bullseye-unstable.yml
@@ -77,7 +77,11 @@ jobs:
                      playbooks/configure_pi_top_os.yml
 
           echo "==> Running finalise_pi_top_image playbook..."
-          ${ANSIBLE} playbooks/finalise_pi_top_image.yml
+          ${ANSIBLE} --extra-vars distro_name=${{ env.DISTRO_NAME }} \
+                     --extra-vars build_number=${{ github.run_number || github.run_id }} \
+                     --extra-vars build_repo_name="${{ env.REPO_NAME }}" \
+                     --extra-vars architecture="${{ matrix.build_type_name }}" \
+                     playbooks/finalise_pi_top_image.yml
 
           echo "==> Running analyse_build playbook..."
           ${ANSIBLE} --extra-vars build_number=${{ github.run_number || github.run_id }} \

--- a/.github/workflows/bullseye-unstable.yml
+++ b/.github/workflows/bullseye-unstable.yml
@@ -90,10 +90,14 @@ jobs:
       - name: Get zip filename
         run: echo "ZIP_FILENAME=$(find playbooks/artifacts -name "*.zip" | head -n1)" >> $GITHUB_ENV
 
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
       - name: Upload OS zip artifact
         uses: actions/upload-artifact@v2
         with:
-          name: pi-topOS-${{ env.REPO_NAME }}-${{ env.DISTRO_NAME }}-${{ github.run_number || github.run_id }}-${{ matrix.build_type_name }}
+          name: pi-topOS_{{ env.DISTRO_NAME }}_{{ env.REPO_NAME }}_{{ matrix.build_type_name }}_{{ steps.date.outputs.date }}_B{{ github.run_number || github.run_id }}
           if-no-files-found: error
           path: ${{ env.ZIP_FILENAME }}
 

--- a/.github/workflows/bullseye-unstable.yml
+++ b/.github/workflows/bullseye-unstable.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Upload OS zip artifact
         uses: actions/upload-artifact@v2
         with:
-          name: pi-topOS_{{ env.DISTRO_NAME }}_{{ env.REPO_NAME }}_{{ matrix.build_type_name }}_{{ steps.date.outputs.date }}_B{{ github.run_number || github.run_id }}
+          name: pi-topOS_${{ env.DISTRO_NAME }}_${{ env.REPO_NAME }}_${{ matrix.build_type_name }}_${{ steps.date.outputs.date }}_B${{ github.run_number || github.run_id }}
           if-no-files-found: error
           path: ${{ env.ZIP_FILENAME }}
 

--- a/playbooks/finalise_pi_top_image.yml
+++ b/playbooks/finalise_pi_top_image.yml
@@ -9,7 +9,11 @@
     PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-openjdk-armhf/bin"
   vars:
     output_directory: artifacts
-
+    build_repo_name: unstable
+    build_number: 0
+    distro_name: bullseye
+    architecture: armhf
+  
   tasks:
 
     - name: Remove qemu-arm-static from OS as we have finished chrooting
@@ -104,23 +108,20 @@
       shell: "truncate --size={{ final_image_size }} new-image.img"
 
     - set_fact:
-        output_image_filename: "{{ ansible_date_time.date }}-pi-topOS.img"
+        output_filename: "pi-topOS_{{ distro_name }}_{{ build_repo_name }}_{{ architecture }}_{{ ansible_date_time.date }}_B{{ build_number }}"
 
     - name: Create a hard link to the image to use as the output filename
       file:
         src: "{{ playbook_dir }}/new-image.img"
-        dest: "{{ output_directory }}/{{ output_image_filename }}"
+        dest: "{{ output_directory }}/{{ output_filename }}.img"
         state: hard
-
-    - set_fact:
-        zip_filename: "pi-topOS_{{ ansible_date_time.date }}_{{ ansible_date_time.hour }}-{{ ansible_date_time.minute }}-{{ ansible_date_time.second }}.zip"
 
     - name: Compress image into zip
       archive:
         path:
-          - "{{ output_directory }}/{{ output_image_filename }}"
+          - "{{ output_directory }}/{{ output_filename }}.img"
           - "{{ output_directory }}/metadata.txt"
-        dest: "{{ output_directory }}/{{ zip_filename }}"
+        dest: "{{ output_directory }}/{{ output_filename }}.zip"
         format: zip
       register: zip_result
 
@@ -131,5 +132,5 @@
 
     - name: Remove the hard link to avoid any confusion
       file:
-        dest: "{{ output_directory }}/{{ output_image_filename }}"
+        dest: "{{ output_directory }}/{{ output_filename }}"
         state: absent


### PR DESCRIPTION
Update the github artifact, zip and image name to fit the same format wit dist, repo, architecture, date & build number:
- pi-topOS_bullseye_release_armhf_2022-02-16_B23.zip  (build number 23, with prefix 'B' for build)
- pi-topOS_bullseye_release_armhf_2022-02-16_B23.zip
- pi-topOS_bullseye_release_armhf_2022-02-16_B23.img

Also, stop pushing experimental builds to Google Cloud.