### PR TITLE
Fix swapfile permissions and header on armhf

### DIFF
--- a/playbooks/configure_pi_top_os.yml
+++ b/playbooks/configure_pi_top_os.yml
@@ -123,7 +123,6 @@
         - dpms-timeout-5mins
         - disable-openbox-session-right-click-menu
 
-    # TODO: confirm that this is supposed to be skipped
     - name: Apply full-install 32-bit only patches
       when: build_type == "armhf"
       patch:
@@ -137,6 +136,12 @@
       shell: |
         sed -i "s|CONF_SWAPSIZE=100|CONF_SWAPSIZE={{ swapfile_size_mb }}|" /etc/dphys-swapfile
         dd if=/dev/zero of=/var/swap bs=1024 count=$((1024 * {{ swapfile_size_mb }}))
+
+    - name: Fix swapfile permissions and header
+      when: build_type == "armhf"
+      shell: |
+        chmod 0600 /var/swap
+        mkswap /var/swap
 
 ###########################################
 # Onboarding setup: systemd/dbus services #


### PR DESCRIPTION
`dphys-swapfile` service fails on `armhf`: 

```
pi@pi-top:~ $ journalctl -b -u dphys-swapfile.service
-- Journal begins at Thu 2022-12-01 13:20:51 GMT, ends at Thu 2022-12-01 13:24:15 GMT. --
Dec 01 13:21:01 pi-top systemd[1]: Starting dphys-swapfile - set up, mount/unmount, and delete a swap file...
Dec 01 13:21:02 pi-top dphys-swapfile[568]: want /var/swap=512MByte, checking existing: keeping it
Dec 01 13:21:02 pi-top dphys-swapfile[709]: swapon: /var/swap: insecure permissions 0644, 0600 suggested.
Dec 01 13:21:02 pi-top dphys-swapfile[709]: swapon: /var/swap: read swap header failed
Dec 01 13:21:02 pi-top systemd[1]: dphys-swapfile.service: Main process exited, code=exited, status=255/EXCEPTION
Dec 01 13:21:02 pi-top systemd[1]: dphys-swapfile.service: Failed with result 'exit-code'.
Dec 01 13:21:02 pi-top systemd[1]: Failed to start dphys-swapfile - set up, mount/unmount, and delete a swap file.
```

Setting file permissions to 600 and correcting headers using `mkswap` seems to fix the issue.